### PR TITLE
pkg/client: consider 5xx errors when requesting /v2/ endpoint

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/pflag v1.0.5
 	github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80
+	golang.org/x/sys v0.0.0-20220422013727-9388b58f7150 // indirect
 	k8s.io/kubernetes v1.19.3
 )
 

--- a/go.sum
+++ b/go.sum
@@ -619,6 +619,8 @@ golang.org/x/sys v0.0.0-20200327173247-9dae0f8f5775/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200622214017-ed371f2e16b4 h1:5/PjkGUjvEU5Gl6BxmvKRPpqo2uNMv4rcHBMwzk/st8=
 golang.org/x/sys v0.0.0-20200622214017-ed371f2e16b4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20220422013727-9388b58f7150 h1:xHms4gcpe1YE7A3yIllJXP16CMAGuqwO2lX1mTyyRRc=
+golang.org/x/sys v0.0.0-20220422013727-9388b58f7150/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -119,6 +119,9 @@ func (c *Client) auth(creds auth.CredentialStore, scope string, actions ...strin
 	if err != nil {
 		return fmt.Errorf("get challenges from /v2/: %s", err)
 	}
+	if resp.StatusCode >= http.StatusInternalServerError {
+		return fmt.Errorf("server responded with error: %d", resp.StatusCode)
+	}
 	defer resp.Body.Close()
 
 	manager := challenge.NewSimpleManager()


### PR DESCRIPTION
also upgrade golang.org/x/sys due to an error, see
https://stackoverflow.com/questions/71507321/go-1-18-build-error-on-mac-unix-syscall-darwin-1-13-go253-golinkname-mus
for details

---

FTR I tested this against Distribution deployed to OCP running on http and it worked 🎉